### PR TITLE
Change versioning (0.1.0 to 1.0.0)

### DIFF
--- a/lib/mddo_toolbox_cli_version.rb
+++ b/lib/mddo_toolbox_cli_version.rb
@@ -2,5 +2,5 @@
 
 module MddoToolboxCli
   # mddo_toolbox_cli version
-  VERSION = '0.1.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
It uses netomox-exp/batfish-wrapper v1.0.0 API. (REST APIs used in copy_to_emulated_env demo are incompatible backwards.)
So developoment branch was v0.1.0 but released as v1.0.0. 